### PR TITLE
[ci skip] Fix typo in action_controller_overview.md

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1077,7 +1077,7 @@ class ClientsController < ApplicationController
 end
 ```
 
-This will read and stream the file 4 kB at the time, avoiding loading the entire file into memory at once. You can turn off streaming with the `:stream` option or adjust the block size with the `:buffer_size` option.
+This will read and stream the file 4 kB at a time, avoiding loading the entire file into memory at once. You can turn off streaming with the `:stream` option or adjust the block size with the `:buffer_size` option.
 
 If `:type` is not specified, it will be guessed from the file extension specified in `:filename`. If the content-type is not registered for the extension, `application/octet-stream` will be used.
 


### PR DESCRIPTION
"stream the file 4 kB at the time" --> "stream the file 4 kb at a time"